### PR TITLE
upstream config changed "ssl" -> "security"

### DIFF
--- a/debian/isso.conf
+++ b/debian/isso.conf
@@ -60,10 +60,10 @@ host = localhost
 # SMTP port
 port = 465
 
-# use SSL to connect to the server. Python probably does
-# not validate the certificate. Needs research, though. But
-# you should use a dedicated email account anyways.
-ssl = on
+# use a secure connection to the server, possible values: "none", "starttls"
+# or "ssl". Python 2.X probably does not validate certificates (needs
+# research). But you should use a dedicated email account anyways.
+security = ssl
 
 # recipient address, e.g. your email address
 to =


### PR DESCRIPTION
to be consistent with original project

The feature "ssl" no longer works.
