### PR TITLE
updated watch to use debian pypi

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,4 @@
 version=3
-https://pypi.python.org/packages/source/i/isso/ isso-(.*)\.tar\.gz
+opts=uversionmangle=s/(rc|a|b|c)/~$1/ \
+http://pypi.debian.net/isso/isso-(.+)\.(?:zip|tgz|tbz|txz|(?:tar\.(?:gz|bz2|xz)))
 


### PR DESCRIPTION
, cause urls broke at python pypi, see https://wiki.debian.org/Python/LibraryStyleGuide#debian.2Fwatch