### PR TITLE
Fakeroot is also needed

### DIFF
--- a/debian/README.md
+++ b/debian/README.md
@@ -8,7 +8,7 @@ Debian package for [isso comments server](https://github.com/posativ/isso/).
 
 First you need to install `dpkg-dev` package.
 
-    # apt-get install python-all debhelper dpkg-dev
+    # apt-get install python-all debhelper dpkg-dev fakeroot
 
 Then do quickly a build for your own use (produce only unsigned binary package for your arch):
 


### PR DESCRIPTION
```console
eliaso@rauduskoivu:~/build/debian-isso$ dpkg-buildpackage -rfakeroot -uc -b
dpkg-buildpackage: error: fakeroot not found, either install the fakeroot
package, specify a command with the -r option, or run this as root
```